### PR TITLE
Change lastMod unixtimestamp int64 (nano) to seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Frontail is written in Go to provide a fast and easy way to stream contents of a
 
 ### Quick Start
 
+* Get requirement
+  - `go get github.com/gorilla/websocket`
+  - `go get github.com/rs/zerolog`
 * Build as `go build -o frontail main.go` or download a binary file from [Releases](https://github.com/krish512/frontail/releases) page
 * Execute in shell `frontail -p 8080 /var/log/syslog`
 * Visit [http://127.0.0.1:8080](http://127.0.0.1:8080)

--- a/main.go
+++ b/main.go
@@ -117,8 +117,8 @@ func serveWs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var lastMod time.Time
-	if n, err := strconv.ParseInt(r.FormValue("lastMod"), 16, 64); err == nil {
-		lastMod = time.Unix(0, n)
+	if n, err := strconv.ParseInt(r.FormValue("lastMod"), 10, 64); err == nil {
+		lastMod = time.Unix(n, 0)
 	}
 
 	go writer(ws, lastMod)
@@ -148,7 +148,7 @@ func serveHome(w http.ResponseWriter, r *http.Request) {
 	}{
 		r.Host + r.URL.Path,
 		string(p),
-		strconv.FormatInt(lastMod.UnixNano(), 16),
+		strconv.FormatInt(lastMod.Unix(), 10),
 		filename,
 	}
 	homeTempl.Execute(w, &v)


### PR DESCRIPTION
Reason for the change: offer this possibility to initiate a call WITHOUT downloading the complete file (easily) using a simple '$(date +%s)' for instance.